### PR TITLE
Save GSP data as Zarr, add gsp_id and installedcapacity_mwp (#93)

### DIFF
--- a/src/open_data_pvnet/scripts/collect_pvlive_data.py
+++ b/src/open_data_pvnet/scripts/collect_pvlive_data.py
@@ -49,18 +49,6 @@ ds = xr.Dataset.from_dataframe(df)
 # Rearrange dimensions so that the time dimension comes first
 ds = ds.transpose("time_utc", "gsp_id")
 
-# Saving the data to a local path
-local_path = os.path.join(os.path.dirname(__file__), "..", "data", "gsp.zarr")
-
-# Create the directories if they do not already exist
-os.makedirs(os.path.dirname(local_path), exist_ok=True)
-
-# Save the dataset as a Zarr file to the local path
-ds.to_zarr(local_path, consolidated=True, mode="w")
-
-logger.info(f"Zarr dataset successfully stored at: {local_path}")
-
-
 # ---- Upload to S3 ----
 
 # S3 bucket path - replace with your actual S3 bucket path


### PR DESCRIPTION
# Pull Request

## Description

This PR implements the changes requested in **Issue #93**.

- Saves GSP data in **Zarr format**
- Adds the `gsp_id` dimension with a fixed value of `0`
- Retrieves `installedcapacity_mwp` from PVLive
- Ensures compatibility with the `open_gsp()` function

Fixes #93

## How Has This Been Tested?

- Ran the updated script locally to verify:
  - The Zarr dataset is successfully created.
  - The dimensions and variables (`gsp_pv_generation_mw`, `gsp_installedcapacity_mwp`, `gsp_id`) are correctly formatted.
- Manually checked the Zarr structure using `xarray` to confirm it matches expectations.

✅ Sanity check performed: Output dataset plotted and values reviewed for correctness.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (manual test)
- [x] I have checked my code and corrected any misspellings
