### PR TITLE
Fix GFS dataset import when ocf-data-sampler constants are unavailable

### DIFF
--- a/src/open_data_pvnet/nwp/gfs_dataset.py
+++ b/src/open_data_pvnet/nwp/gfs_dataset.py
@@ -214,12 +214,12 @@ class GFSDataSampler(Dataset):
             raise e
 
 
-# Uncomment the block below to test
-if __name__ == "__main__":
-    dataset_path = "s3://ocf-open-data-pvnet/data/gfs.zarr"
-    config_path = "src/open_data_pvnet/configs/gfs_data_config.yaml"
-    dataset = open_gfs(dataset_path)
-    dataset = handle_nan_values(dataset, method="fill", fill_value=0.0)
-    sampler = GFSDataSampler(dataset, config_filename=config_path, start_time="2023-01-01T00:00:00", end_time="2023-01-30T00:00:00")
-    sample = sampler[0]
-    print(sample)
+# # Uncomment the block below to test
+# if __name__ == "__main__":
+#     dataset_path = "s3://ocf-open-data-pvnet/data/gfs.zarr"
+#     config_path = "src/open_data_pvnet/configs/gfs_data_config.yaml"
+#     dataset = open_gfs(dataset_path)
+#     dataset = handle_nan_values(dataset, method="fill", fill_value=0.0)
+#     sampler = GFSDataSampler(dataset, config_filename=config_path, start_time="2023-01-01T00:00:00", end_time="2023-01-30T00:00:00")
+#     sample = sampler[0]
+#     print(sample)

--- a/src/open_data_pvnet/nwp/gfs_dataset.py
+++ b/src/open_data_pvnet/nwp/gfs_dataset.py
@@ -11,9 +11,21 @@ import xarray as xr
 from torch.utils.data import Dataset
 from ocf_data_sampler.config import load_yaml_configuration
 from ocf_data_sampler.torch_datasets.utils.valid_time_periods import find_valid_time_periods
-from ocf_data_sampler.constants import NWP_MEANS, NWP_STDS
 import fsspec
 import numpy as np
+
+
+try:
+    from ocf_data_sampler.constants import NWP_MEANS, NWP_STDS
+    HAS_NWP_STATS = True
+except ImportError:
+    NWP_MEANS = None
+    NWP_STDS = None
+    HAS_NWP_STATS = False
+    logging.warning(
+        "NWP_MEANS and NWP_STDS not available in this version of ocf-data-sampler. "
+        "GFS normalization will be skipped."
+    )
 
 
 # Configure logging
@@ -166,6 +178,10 @@ class GFSDataSampler(Dataset):
             xr.Dataset: The normalized dataset.
         """
         logging.info("Starting normalization...")
+
+        if not HAS_NWP_STATS:
+            return dataset
+
         provider = self.config.input_data.nwp.gfs.provider
         dataset_channels = dataset.channel.values
         mean_channels = NWP_MEANS[provider].channel.values
@@ -198,12 +214,12 @@ class GFSDataSampler(Dataset):
             raise e
 
 
-# # Uncomment the block below to test
-# if __name__ == "__main__":
-#     dataset_path = "s3://ocf-open-data-pvnet/data/gfs.zarr"
-#     config_path = "src/open_data_pvnet/configs/gfs_data_config.yaml"
-#     dataset = open_gfs(dataset_path)
-#     dataset = handle_nan_values(dataset, method="fill", fill_value=0.0)
-#     sampler = GFSDataSampler(dataset, config_filename=config_path, start_time="2023-01-01T00:00:00", end_time="2023-01-30T00:00:00")
-#     sample = sampler[0]
-#     print(sample)
+# Uncomment the block below to test
+if __name__ == "__main__":
+    dataset_path = "s3://ocf-open-data-pvnet/data/gfs.zarr"
+    config_path = "src/open_data_pvnet/configs/gfs_data_config.yaml"
+    dataset = open_gfs(dataset_path)
+    dataset = handle_nan_values(dataset, method="fill", fill_value=0.0)
+    sampler = GFSDataSampler(dataset, config_filename=config_path, start_time="2023-01-01T00:00:00", end_time="2023-01-30T00:00:00")
+    sample = sampler[0]
+    print(sample)

--- a/tests/test_gfs_dataset.py
+++ b/tests/test_gfs_dataset.py
@@ -1,0 +1,133 @@
+"""
+Tests for GFS dataset functionality.
+
+These tests cover only core guarantees and avoid integration complexity.
+"""
+
+import pytest
+import numpy as np
+import pandas as pd
+import xarray as xr
+from unittest.mock import MagicMock, patch
+
+from open_data_pvnet.nwp.gfs_dataset import (
+    open_gfs,
+    handle_nan_values,
+    GFSDataSampler,
+)
+
+
+@pytest.fixture
+def sample_gfs_data():
+    """Minimal GFS-like DataArray with a NaN value."""
+    data = np.array([[[[[np.nan]]]]])
+    return xr.DataArray(
+        data,
+        dims=["init_time_utc", "step", "channel", "latitude", "longitude"],
+        coords={
+            "init_time_utc": [pd.Timestamp("2023-01-01")],
+            "step": [np.timedelta64(0, "h")],
+            "channel": ["t2m"],
+            "latitude": [50.0],
+            "longitude": [0.0],
+        },
+    )
+
+
+@pytest.fixture
+def sample_gfs_data_with_init_time():
+    """DataArray using `init_time` to test renaming."""
+    data = np.zeros((1, 1, 1, 1, 1))
+    return xr.DataArray(
+        data,
+        dims=["init_time", "step", "channel", "latitude", "longitude"],
+        coords={
+            "init_time": [pd.Timestamp("2023-01-01")],
+            "step": [np.timedelta64(0, "h")],
+            "channel": ["t2m"],
+            "latitude": [50.0],
+            "longitude": [0.0],
+        },
+    )
+
+
+@pytest.fixture
+def mock_config():
+    """Minimal config object for sampler initialization."""
+    config = MagicMock()
+    config.input_data.nwp.gfs.interval_start_minutes = 0
+    config.input_data.nwp.gfs.interval_end_minutes = 60
+    config.input_data.nwp.gfs.time_resolution_minutes = 60
+    config.input_data.nwp.gfs.provider = "gfs"
+    return config
+
+
+class TestHandleNanValues:
+    def test_fill_nan(self, sample_gfs_data):
+        """NaN values should be filled correctly."""
+        result = handle_nan_values(sample_gfs_data, method="fill", fill_value=0.0)
+        assert not np.isnan(result.values).any()
+        assert result.values[0, 0, 0, 0, 0] == 0.0
+
+
+class TestOpenGfs:
+    def test_renames_init_time(self, sample_gfs_data_with_init_time):
+        """`init_time` should be renamed to `init_time_utc`."""
+        mock_dataset = MagicMock()
+        mock_dataset.to_array.return_value = sample_gfs_data_with_init_time
+
+        with patch("open_data_pvnet.nwp.gfs_dataset.fsspec.get_mapper"), \
+             patch("open_data_pvnet.nwp.gfs_dataset.xr.open_dataset", return_value=mock_dataset):
+
+            result = open_gfs("s3://dummy/gfs.zarr")
+
+            assert "init_time_utc" in result.dims
+            assert "init_time" not in result.dims
+
+
+class TestGFSDataSampler:
+    def test_sampler_initialization(self, sample_gfs_data, mock_config):
+        """Sampler should initialize with valid times."""
+        valid_times = pd.DataFrame(
+            {"t0": [pd.Timestamp("2023-01-01")]}
+        )
+
+        with patch(
+            "open_data_pvnet.nwp.gfs_dataset.load_yaml_configuration",
+            return_value=mock_config,
+        ), patch(
+            "open_data_pvnet.nwp.gfs_dataset.find_valid_time_periods",
+            return_value=valid_times,
+        ):
+            sampler = GFSDataSampler(
+                dataset=sample_gfs_data,
+                config_filename="dummy.yaml",
+            )
+
+            assert len(sampler) == 1
+
+
+class TestNormalizationFallback:
+    def test_no_crash_without_nwp_stats(self, sample_gfs_data, mock_config):
+        """Sampler should not crash if NWP stats are unavailable."""
+        valid_times = pd.DataFrame(
+            {"t0": [pd.Timestamp("2023-01-01")]}
+        )
+
+        with patch(
+            "open_data_pvnet.nwp.gfs_dataset.load_yaml_configuration",
+            return_value=mock_config,
+        ), patch(
+            "open_data_pvnet.nwp.gfs_dataset.find_valid_time_periods",
+            return_value=valid_times,
+        ), patch(
+            "open_data_pvnet.nwp.gfs_dataset.HAS_NWP_STATS",
+            False,
+        ):
+            sampler = GFSDataSampler(
+                dataset=sample_gfs_data,
+                config_filename="dummy.yaml",
+            )
+
+            sample = sampler[0]
+            assert sample is not None


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes an import-time crash in `open_data_pvnet.nwp.gfs_dataset`.

`NWP_MEANS` and `NWP_STDS` were introduced in `ocf-data-sampler`
(openclimatefix/ocf-data-sampler#145) but are not yet part of a PyPI release.
As a result, importing `gfs_dataset` fails when installing dependencies
from PyPI with `ocf-data-sampler==0.2.32`.

This change adds a graceful fallback when these constants are unavailable,
allowing the module to be imported and used without normalization.
When the constants are present in a future release, the existing
normalization logic will be used automatically.

Minimal regression tests are included to lock this behavior.

Fixes #

---

## How Has This Been Tested?

The following tests were run locally:

- `pytest tests/test_gfs_dataset.py`
- `pytest`

These tests verify that:
- `gfs_dataset` imports successfully when normalization constants are missing
- NaN handling behaves as expected
- `init_time` is correctly renamed to `init_time_utc`
- `GFSDataSampler` initializes without crashing

- [x] Yes

_If your changes affect data processing, have you plotted any changes?_

- [ ] Yes (not applicable — behavior is unchanged when constants are present)

---

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
